### PR TITLE
Fix the error of `sml-insert-form`

### DIFF
--- a/sml-mode.el
+++ b/sml-mode.el
@@ -1589,7 +1589,7 @@ completion from `sml-forms-alist'."
   (interactive
    (list (completing-read
 	  (format "Form to insert (default %s): " sml-last-form)
-	  sml-forms-alist nil t nil nil sml-forms-alist)
+	  sml-forms-alist nil t nil nil sml-last-form sml-forms-alist)
 	 current-prefix-arg))
   (setq sml-last-form name)
   (unless (or (not newline)


### PR DESCRIPTION
The present version is erroneous; the `completing-read` need `DEF` argument for default value but missing in here. I've amend it. By the way, thank you for this plugin, I really appreciate this great work!